### PR TITLE
Switch from armv8-a to armv8-2a architecture revision for aarch32

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -38,10 +38,10 @@ TARGET_CPU_ABI2 :=
 TARGET_CPU_VARIANT := cortex-a76
 
 TARGET_2ND_ARCH := arm
-TARGET_2ND_ARCH_VARIANT := armv8-a
+TARGET_2ND_ARCH_VARIANT := armv8-2a
 TARGET_2ND_CPU_ABI := armeabi-v7a
 TARGET_2ND_CPU_ABI2 := armeabi
-TARGET_2ND_CPU_VARIANT := cortex-a76
+TARGET_2ND_CPU_VARIANT := cortex-a55
 
 # Bluetooth
 BOARD_CUSTOM_BT_CONFIG := $(COMMON_PATH)/bluetooth/libbt_vndcfg.txt


### PR DESCRIPTION
The armv8-2a architecture revision is the newest version that you can target for aarch32 and is supported by this SoC, as evident by the dotproduct variant of it being used for aarch64 already and the age of the chip / the cores used in it.

The older Exynos 9820 has already been doing this from the beginning and the benefits of it should be similar to those of switching from armv8-a to armv8-2a on aarch64, maybe a bit less profound.

* The Cortex-A55 is being targeted for aarch32 because it won't compile otherwise.

[1]: https://android.googlesource.com/platform/build/soong/+/refs/heads/main/cc/config/arm_device.go
[2] https://developer.arm.com/Processors/Cortex-A55
[3] https://developer.arm.com/Processors/Cortex-A78
[4]: https://github.com/LineageOS/android_device_samsung_exynos9820-common/blob/lineage-20/BoardConfigCommon.mk